### PR TITLE
Fixed secure session cookies

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -34,6 +34,7 @@ async function bootstrap() {
       }),
       cookie: {
         maxAge: 60000 * 60 * 24,
+        secure: true,
       },
       secret: process.env.SESSION_COOKIE,
       resave: false,


### PR DESCRIPTION
This removes the security alert from nest js cookies. This may break development cookies but we will see.